### PR TITLE
Fix overflow issue in small screen and improve the UI

### DIFF
--- a/src/app/(app)/docs/elements/[elementType]/page.tsx
+++ b/src/app/(app)/docs/elements/[elementType]/page.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { cn } from "@/lib/utils";
-import { Shell } from "@/components/shell";
 import { Previews } from "@/content/previews";
 import { ComponentTypeEnum } from "@/constants/enum";
 import ComponentCodePreviewDialog from "@/components/component-code-preview-dialog";
-import ComponentPreview from "@/components/component-preview";
 
 interface ElementType {
     label: string;
@@ -24,19 +22,17 @@ export default function Page({ params }: { params: { elementType: string } }) {
     }
 
     return (
-        <Shell className="px-0 w-full">
-            <div className={cn("grid gap-2 grid-cols-1 md:grid-cols-3 lg:grid-cols-4")}>
-                {[...filteredElements]?.map((comp, index) => {
-                    return (
-                        <ComponentCodePreviewDialog
-                            component={React.createElement(comp.component)}
-                            label={comp.label}
-                            key={index}
-                            code={comp.rawCode}
-                        />
-                    );
-                })}
-            </div>
-        </Shell>
+        <div className={cn("grid gap-2 grid-cols-1 md:grid-cols-3 lg:grid-cols-5")}>
+            {[...filteredElements]?.map((comp, index) => {
+                return (
+                    <ComponentCodePreviewDialog
+                        component={React.createElement(comp.component)}
+                        label={comp.label}
+                        key={index}
+                        code={comp.rawCode}
+                    />
+                );
+            })}
+        </div>
     );
 }

--- a/src/app/(app)/docs/layout.tsx
+++ b/src/app/(app)/docs/layout.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { cn } from "@/lib/utils";
 import { Shell } from "@/components/shell";
 import DocsSidebar from "@/components/docs-sidebar";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -10,13 +11,25 @@ interface PageProps {
 export default function DocsLayout({ children }: PageProps) {
     return (
         <Shell>
-            <div className="mt-10 flex-1 items-start md:grid md:grid-cols-[240px_minmax(0,1fr)] md:gap-6 lg:grid-cols-[250px_minmax(0,1fr)]">
-                <aside className="w-full top-20 z-30 hidden h-[calc(100vh-3.5rem)] shrink-0 md:sticky md:block">
-                    <ScrollArea className="h-full pr-6">
+            <div
+                className={cn(
+                    "relative mt-10 flex-1 items-start overflow-hidden md:overflow-visible",
+                    "md:grid md:grid-cols-[240px_minmax(0,1fr)] md:gap-6 lg:grid-cols-[250px_minmax(0,1fr)]"
+                )}
+            >
+                <aside
+                    className={cn(
+                        "w-full hidden h-[calc(100vh-3.5rem)] shrink-0",
+                        "md:top-20 md:sticky md:z-30 md:block"
+                    )}
+                >
+                    <ScrollArea className="h-full">
                         <DocsSidebar />
                     </ScrollArea>
                 </aside>
-                {children}
+
+                {/* main content */}
+                <main>{children}</main>
             </div>
         </Shell>
     );


### PR DESCRIPTION
This PR makes the code snippets responsive on small screens preventing screen to be overflowing horizontally.
The problem is not in code-renderer.tsx as explained on issue but it is on the docs->layout.tsx

Fixes #1
